### PR TITLE
Allow multiple users

### DIFF
--- a/commands
+++ b/commands
@@ -38,7 +38,7 @@ case "$1" in
     cp "$(dirname "$0")/templates/http-auth.conf" "$APP_ROOT/nginx.conf.d"
     sed -i "s,{APP_ROOT},$APP_ROOT," "$APP_ROOT/nginx.conf.d/http-auth.conf"
     HASHED_PASSWORD=$(mkpasswd -m sha-512 "$AUTH_PASSWORD")
-    echo "$AUTH_USERNAME:$HASHED_PASSWORD" > "$APP_ROOT/htpasswd"
+    echo "$AUTH_USERNAME:$HASHED_PASSWORD" >> "$APP_ROOT/htpasswd"
     reload_nginx
     dokku_log_verbose "done"
     ;;


### PR DESCRIPTION
Instead of regenerating the htpasswd file, it now appends to it to allow for multiple users to be added.

This might need more intelligent updating of existing users instead of just appending them. Also one could argue that there should be a way to remove a user from the auth. (including a warning if auth=on but there are no users left to match against)

- [ ] find possibly already existing user
- [ ] ask to update / overwrite existing user
- [ ] allow for removing existing user
- [ ] if no users remain in the passwd file, ask what to do (remove auth, leave locked with no way of getting in or immediately ask for a new username/password

Relates to #6